### PR TITLE
Support request throttling and retry-after

### DIFF
--- a/slack-autoarchive.py
+++ b/slack-autoarchive.py
@@ -22,6 +22,7 @@ WHITELIST_KEYWORDS = os.getenv('WHITELIST_KEYWORDS')
 
 THROTTLE_REQUESTS = False
 
+
 # api_endpoint is a string, and payload is a dict
 def slack_api_http(api_endpoint=None, payload=None, method="GET", retry=True):
   global THROTTLE_REQUESTS
@@ -44,7 +45,7 @@ def slack_api_http(api_endpoint=None, payload=None, method="GET", retry=True):
     if response.status_code == requests.codes.ok:
       return response.json()
     elif retry and response.status_code == requests.codes.too_many_requests:
-      THROTTLE_REQUESTS=True
+      THROTTLE_REQUESTS = True
       retry_timeout = 1.2 * float(response.headers['Retry-After'])
       print('Rate-limited. Retrying after ' + str(retry_timeout) + 'ms')
       time.sleep(retry_timeout)


### PR DESCRIPTION
Encountering massive amounts of HTTP 429 codes with a large size company Slack (8k+ channels). This change adds throttling based on Slack guidelines (1 RPS). Throttling starts once the rate limit has been hit for the first time. Retry logic respects the `retry-after` header that Slack API sends back. Requests are retried only one time.

https://api.slack.com/docs/rate-limits
> In general we allow applications that integrate with Slack to send no more than one message per second. We allow bursts over that limit for short periods. However, if your app continues to exceed the limit over a longer period of time it will be rate limited.

>If you go over these limits when using our HTTP based APIs, including Incoming Webhooks, Slack will start returning a HTTP 429 Too Many Requests error, a JSON object containing the number of calls you have been making, and a Retry-After header containing the number of seconds until you can retry.