### PR TITLE
Handle channels that never had a message

### DIFF
--- a/slack-autoarchive.py
+++ b/slack-autoarchive.py
@@ -52,6 +52,10 @@ def get_last_message_timestamp(channel_history, too_old_datetime):
   last_message_datetime = too_old_datetime
   last_bot_message_datetime = too_old_datetime
   skip_subtypes = {'bot_message', 'channel_leave', 'channel_join'}
+
+  if not 'messages' in channel_history:
+    return (last_message_datetime, False) # no messages
+
   for message in channel_history['messages']:
     if 'subtype' in message and message['subtype'] in skip_subtypes:
       last_bot_message_datetime = datetime.fromtimestamp(float(message['ts']))

--- a/slack-autoarchive.py
+++ b/slack-autoarchive.py
@@ -53,8 +53,8 @@ def get_last_message_timestamp(channel_history, too_old_datetime):
   last_bot_message_datetime = too_old_datetime
   skip_subtypes = {'bot_message', 'channel_leave', 'channel_join'}
 
-  if not 'messages' in channel_history:
-    return (last_message_datetime, False) # no messages
+  if 'messages' not in channel_history:
+    return (last_message_datetime, False)  # no messages
 
   for message in channel_history['messages']:
     if 'subtype' in message and message['subtype'] in skip_subtypes:


### PR DESCRIPTION
Finding nice edge cases running on an 8k+ channel Slack instance. The script died due to a missing `message` key in the JSON for a particular channel. I guess it never had any messages, ever!

Easy enough fix. Too bad each run takes 2.4 hours due to rate limiting... testing is slow.