### PR TITLE
Switch to iterative per-record program flow.

### DIFF
--- a/slack-autoarchive.py
+++ b/slack-autoarchive.py
@@ -177,7 +177,7 @@ for channel in get_all_channels():
   sys.stdout.flush()
 
   if not is_channel_whitelisted(channel, whitelist_keywords) \
-    and is_channel_disused(channel, TOO_OLD_DATETIME):
+      and is_channel_disused(channel, TOO_OLD_DATETIME):
     archived_channels.append(channel)
     archive_channel(channel)
 

--- a/slack-autoarchive.py
+++ b/slack-autoarchive.py
@@ -176,8 +176,8 @@ for channel in get_all_channels():
   sys.stdout.write('.')
   sys.stdout.flush()
 
-  if not is_channel_whitelisted(channel, whitelist_keywords) \
-      and is_channel_disused(channel, TOO_OLD_DATETIME):
+  if (not is_channel_whitelisted(channel, whitelist_keywords) and
+    is_channel_disused(channel, TOO_OLD_DATETIME)):
     archived_channels.append(channel)
     archive_channel(channel)
 

--- a/slack-autoarchive.py
+++ b/slack-autoarchive.py
@@ -25,6 +25,20 @@ THROTTLE_REQUESTS  = False
 SKIP_SUBTYPES      = {'channel_leave', 'channel_join'}  # 'bot_message'
 
 
+def get_whitelist_keywords():
+  keywords = []
+  if os.path.isfile('whitelist.txt'):
+    with open('whitelist.txt') as f:
+      keywords = f.readlines()
+
+  # remove whitespace characters like `\n` at the end of each line
+  keywords = map(lambda x: x.strip(), keywords)
+
+  if WHITELIST_KEYWORDS:
+    keywords.append(WHITELIST_KEYWORDS.split(','))
+  return keywords
+
+
 # api_endpoint is a string, and payload is a dict
 def slack_api_http(api_endpoint=None, payload=None, method="GET", retry=True):
   global THROTTLE_REQUESTS
@@ -94,53 +108,27 @@ def get_last_message_timestamp(channel_history, too_old_datetime):
     return (last_message_datetime, True)
 
 
-def get_inactive_channels(all_unarchived_channels, too_old_datetime):
-  print('Find inactive channels...')
+def is_channel_disused(channel, too_old_datetime):
+  num_members = channel['num_members']
   payload  = {'inclusive': 0, 'oldest': 0, 'count': 50}
   api_endpoint = 'channels.history'
-  inactive_channels = []
-  for channel in all_unarchived_channels:
-    sys.stdout.write('.')
-    sys.stdout.flush()
-    num_members = int(channel['num_members'])
-    if num_members == 0:
-      inactive_channels.append(channel)
-    else:
-      payload['channel'] = channel['id']
-      channel_history = slack_api_http(api_endpoint=api_endpoint, payload=payload)
-      (last_message_datetime, is_user) = get_last_message_timestamp(channel_history, datetime.fromtimestamp(float(channel['created'])))
-      # mark inactive if last message is too old, but don't
-      # if there have been bot messages and the channel has
-      # at least the minimum number of members
-      channel_not_too_big = (MIN_MEMBERS == 0 or MIN_MEMBERS > num_members)
-      if last_message_datetime <= too_old_datetime and channel_not_too_big:
-        inactive_channels.append(channel)
-  return inactive_channels
+
+  payload['channel'] = channel['id']
+  channel_history = slack_api_http(api_endpoint=api_endpoint, payload=payload)
+  (last_message_datetime, is_user) = get_last_message_timestamp(channel_history, datetime.fromtimestamp(float(channel['created'])))
+  # mark inactive if last message is too old, but don't
+  # if there have been bot messages and the channel has
+  # at least the minimum number of members
+  has_min_users = (MIN_MEMBERS == 0 or MIN_MEMBERS > num_members)
+  return last_message_datetime <= too_old_datetime and (not is_user or has_min_users)
 
 
 # If you add channels to the WHITELIST_KEYWORDS constant they will be exempt from archiving.
-def filter_out_exempt_channels(all_unarchived_channels):
-    if not os.path.isfile('whitelist.txt'):
-      return all_unarchived_channels
-    keywords = []
-    with open('whitelist.txt') as f:
-        keywords = f.readlines()
-    # remove whitespace characters like `\n` at the end of each line
-    keywords = map(lambda x: x.strip(), keywords)
-
-    if WHITELIST_KEYWORDS:
-      keywords.append(WHITELIST_KEYWORDS.split(','))
-
-    channels_not_exempt = []
-    for channel in all_unarchived_channels:
-      whitelisted = False
-      for kw in keywords:
-        if kw in channel['name']:
-          whitelisted = True
-          break
-      if not whitelisted:
-        channels_not_exempt.append(channel)
-    return channels_not_exempt
+def is_channel_whitelisted(channel, keywords):
+  for kw in keywords:
+    if kw in channel['name']:
+      return True
+  return False
 
 
 def send_channel_message(channel_id, message):
@@ -154,24 +142,25 @@ def write_log_entry(file_name, entry):
     logfile.write(entry + '\n')
 
 
-def archive_inactive_channels(channels):
-  print('Archive inactive channels...')
+def archive_channel(channel):
   api_endpoint = 'channels.archive'
-  for channel in channels:
-    stdout_message = 'Archiving channel... %s' % channel['name']
-    if not DRY_RUN:
-      channel_message = 'This channel has had no activity for %s days. It is being auto-archived.' % DAYS_INACTIVE
-      channel_message += ' If you feel this is a mistake you can <https://slack.com/archives/archived|unarchive this channel> to bring it back at any point.'
-      send_channel_message(channel['id'], channel_message)
-      payload        = {'channel': channel['id']}
-      log_message    = str(datetime.now()) + ' ' + stdout_message
-      slack_api_http(api_endpoint=api_endpoint, payload=payload)
-      write_log_entry(AUDIT_LOG, log_message)
+  stdout_message = 'Archiving channel... %s' % channel['name']
+  print(stdout_message)
 
-    print(stdout_message)
+  if not DRY_RUN:
+    channel_message = 'This channel has had no activity for %s days. It is being auto-archived.' % DAYS_INACTIVE
+    channel_message += ' If you feel this is a mistake you can <https://slack.com/archives/archived|unarchive this channel> to bring it back at any point.'
+    send_channel_message(channel['id'], channel_message)
+    payload        = {'channel': channel['id']}
+    log_message    = str(datetime.now()) + ' ' + stdout_message
+    slack_api_http(api_endpoint=api_endpoint, payload=payload)
+    write_log_entry(AUDIT_LOG, log_message)
+
+
+def send_admin_report(channels):
   if ADMIN_CHANNEL:
     channel_names = ', '.join('#' + channel['name'] for channel in channels)
-    admin_msg = 'Archiving channel: %s' % channel_names
+    admin_msg = 'Archiving %d channels: %s' % (len(channels), channel_names)
     if DRY_RUN:
       admin_msg = '[DRY RUN] %s' % admin_msg
     send_channel_message(ADMIN_CHANNEL, admin_msg)
@@ -179,7 +168,17 @@ def archive_inactive_channels(channels):
 
 if DRY_RUN:
   print('THIS IS A DRY RUN. NO CHANNELS ARE ACTUALLY ARCHIVED.')
-all_unarchived_channels = get_all_channels()
-non_exempt_channels     = filter_out_exempt_channels(all_unarchived_channels)
-channels_to_archive     = get_inactive_channels(non_exempt_channels, TOO_OLD_DATETIME)
-archive_inactive_channels(channels_to_archive)
+
+whitelist_keywords = get_whitelist_keywords()
+archived_channels = []
+
+for channel in get_all_channels():
+  sys.stdout.write('.')
+  sys.stdout.flush()
+
+  if not is_channel_whitelisted(channel, whitelist_keywords) \
+    and is_channel_disused(channel, TOO_OLD_DATETIME):
+    archived_channels.append(channel)
+    archive_channel(channel)
+
+send_admin_report(archived_channels)


### PR DESCRIPTION
This change switches up the flow as an optimization for very large
workspaces (15,000 channels with 25% increase per month in my case).
One issue is that when the script fails, it could sometimes cost up to an
hour in lost effort given the API throttling restrictions.

In the old flow, the channel list would be processed in it's entirety in
steps. With the new flow, each channel is analyzed and archived in turn,
such that a failure does not result in significant loss of work.

Overview of changes:
1. The whitelist file is only read one time, rather than for each
   invocation of the method
2. Archive method main loop is removed, but loop body persists and is
   applied once per record
3. get_inactive_channels is renamed to is_channel_disused and operates
   on a single channel record
4. Admin report is send one time at the end of the script as a digest,
   instead of spamming the channel with thousands of messages (in my
   case).
5. When processing a channel, a single . is printed for progress
   tracking. The archived channel log messages are similar and still
   logged.