### PR TITLE
Utf8 safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ A channel will be archived by this script is it doesn't meet any of the followin
 - *Don't panic! It can be unarchived from https://slack.com/archives/archived* However all previous members would be kicked out of the channel and not be automatically invited back.
 - A message will be dropped into the channel saying the channel is being auto archived because of low activity
 - You can always whitelist a channel if it indeed needs to be kept despite meeting the auto-archive criteria.
+
+## Known Issues
+
+- When piping or redirecting Python 2 output, the interpreter defaults to 8-bit/ASCII output. This will cause a crash if your channel names have unicode characters. A workaround is to set this environment variable `PYTHONIOENCODING=UTF-8` prior to executing Python.

--- a/slack-autoarchive.py
+++ b/slack-autoarchive.py
@@ -139,12 +139,12 @@ def send_channel_message(channel_id, message):
 
 def write_log_entry(file_name, entry):
   with open(file_name, 'a') as logfile:
-    logfile.write(entry + '\n')
+    logfile.write(decode(entry) + '\n')
 
 
 def archive_channel(channel):
   api_endpoint = 'channels.archive'
-  stdout_message = 'Archiving channel... %s' % channel['name']
+  stdout_message = 'Archiving channel... %s' % decode(channel['name'])
   print(stdout_message)
 
   if not DRY_RUN:
@@ -159,11 +159,17 @@ def archive_channel(channel):
 
 def send_admin_report(channels):
   if ADMIN_CHANNEL:
-    channel_names = ', '.join('#' + channel['name'] for channel in channels)
+    channel_names = ', '.join('#' + decode(channel['name']) for channel in channels)
     admin_msg = 'Archiving %d channels: %s' % (len(channels), channel_names)
     if DRY_RUN:
       admin_msg = '[DRY RUN] %s' % admin_msg
     send_channel_message(ADMIN_CHANNEL, admin_msg)
+
+def decode(text):
+  try:
+    text = unicode(text, 'utf-8')
+  except TypeError:
+    return text
 
 
 if DRY_RUN:

--- a/slack-autoarchive.py
+++ b/slack-autoarchive.py
@@ -165,6 +165,7 @@ def send_admin_report(channels):
       admin_msg = '[DRY RUN] %s' % admin_msg
     send_channel_message(ADMIN_CHANNEL, admin_msg)
 
+
 def decode(text):
   try:
     text = unicode(text, 'utf-8')


### PR DESCRIPTION
I've encountered a lot of issues with mixed encodings in the logged data. 

The script can technically operate without examining any user-supplied strings, however the auditing and logging functionalities would be hampered. This code fixes most of the issues.

One that it does not help is when piping output to a file. In that case there is a known issue with Python 2.x where the IO format will default to 8-bit/ASCII. Any unicode characters then result in a runtime exception. I added a note to the README on a workaround that's worked well for me.