### PR TITLE
Updating README.md for Slack app OAuth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 - python3
 - Install requirements.txt ( `pip install -r requirements.txt` )
-- Slack API token (https://api.slack.com/docs/oauth-test-tokens)
+- An [OAuth token](https://api.slack.com/docs/oauth) from a [Slack app](https://api.slack.com/slack-apps) on your workspace that has the following permission scopes:
+  - `channels:history`
+  - `channels:read`
+  - `channels:write`
+  - `chat:write:bot`
+  - `chat:write:user`
 
 ## Example Usages
 


### PR DESCRIPTION
Because [legacy tokens are EOL](https://api.slack.com/custom-integrations/legacy-tokens), this is just some updated documentation to explain what [permission scopes](https://api.slack.com/scopes) to include in the [OAuth token](https://api.slack.com/docs/oauth) from a [Slack app](https://api.slack.com/slack-apps).