### PR TITLE
fix dash which should be underscore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ENV DRY_RUN=true
 
 CMD SLACK_TOKEN=${SLACK_TOKEN} \
   DRY_RUN=${DRY_RUN} \
-  python slack-autoarchive.py
+  python slack_autoarchive.py


### PR DESCRIPTION
Running as is gives a file does not exist error, simple `-` to `_` change for file referenced in CMD.