### PR TITLE
Use Alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3-alpine
 
 WORKDIR /build
 


### PR DESCRIPTION
This changes the base image to the upstream's Alpine based variant, which has 2 benefits:

1. Reduces the image size by ~800MB
2. Negates about ~600 or so open CVEs flagged by our container scanning platform that exist in redundant/unused binaries and libs in the "fat" image.

![Screen Shot 2019-07-01 at 7 59 42 PM](https://user-images.githubusercontent.com/854255/60473388-deb5bf80-9c3a-11e9-8361-6cc5165d65bc.png)
