### PR TITLE
feat: Update Slack APIs usage and also add feature to archive black-listed channeld

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 - An [OAuth token](https://api.slack.com/docs/oauth) from a [Slack app](https://api.slack.com/slack-apps) on your workspace that has the following permission scopes:
   - `channels:history`
   - `channels:read`
-  - `channels:write`
-  - `chat:write:bot`
-  - `chat:write:user`
+  - `channels:manage`
+  - `channels:join`
+  - `chat:write`
+  - `chat:write.customize`
+  - `chat:write.public`
 
 ## Example Usages
 

--- a/slack_autoarchive.py
+++ b/slack_autoarchive.py
@@ -68,7 +68,7 @@ This script was run from this repo: https://github.com/Symantec/slack-autoarchiv
         """ Helper function to query the slack api and handle errors and rate limit. """
         # pylint: disable=no-member
         uri = 'https://slack.com/api/' + api_endpoint
-        payload['token'] = self.settings.get('slack_token')
+        headers = {'Authorization': 'Bearer ' + self.settings.get('slack_token')}
         try:
             # Force request to take at least 1 second. Slack docs state:
             # > In general we allow applications that integrate with Slack to send
@@ -78,16 +78,28 @@ This script was run from this repo: https://github.com/Symantec/slack-autoarchiv
                 time.sleep(retry_delay)
 
             if method == 'POST':
-                response = requests.post(uri, data=payload)
+                response = requests.post(uri, json=payload, headers=headers)
             else:
-                response = requests.get(uri, params=payload)
+                response = requests.get(uri, params=payload, headers=headers)
 
             if response.status_code == requests.codes.ok and 'error' in response.json(
-            ) and response.json()['error'] == 'not_authed':
-                self.logger.error(
-                    'Need to setup auth. eg, SLACK_TOKEN=<secret token> python slack-autoarchive.py'
-                )
-                sys.exit(1)
+            ):
+                if response.json()['error'] == 'not_authed':
+                    self.logger.error(
+                        'Need to setup auth. eg, SLACK_TOKEN=<secret token> python slack-autoarchive.py'
+                    )
+                    sys.exit(1)
+                elif response.json()['error'] == 'not_in_channel':
+                    self.logger.error(
+                        'Need to add bot to channel described by ' + str(payload)
+                    )
+                    self.join_channel(payload['channel'])
+                    return response.json()
+                else:            
+                    self.logger.error(
+                        response.json()['error']
+                    )
+                    sys.exit(1)
             elif response.status_code == requests.codes.ok and response.json(
             )['ok']:
                 return response.json()
@@ -100,10 +112,18 @@ This script was run from this repo: https://github.com/Symantec/slack-autoarchiv
             raise Exception(error_msg)
         return None
 
+    def join_channel(self, channel_id):
+        api_endpoint = 'conversations.join'
+        info_payload = {'channel': channel_id}
+        channel_info = self.slack_api_http(api_endpoint=api_endpoint,
+                                           payload=info_payload,
+                                           method='POST')
+        self.logger.info('Joined channel ' + channel_id)
+
     def get_all_channels(self):
         """ Get a list of all non-archived channels from slack channels.list. """
         payload = {'exclude_archived': 1}
-        api_endpoint = 'channels.list'
+        api_endpoint = 'conversations.list'
         channels = self.slack_api_http(api_endpoint=api_endpoint,
                                        payload=payload)['channels']
         all_channels = []
@@ -144,7 +164,7 @@ This script was run from this repo: https://github.com/Symantec/slack-autoarchiv
         """ Return True or False depending on if a channel is "active" or not.  """
         num_members = channel['num_members']
         payload = {'inclusive': 0, 'oldest': 0, 'count': 50}
-        api_endpoint = 'channels.history'
+        api_endpoint = 'conversations.history'
 
         payload['channel'] = channel['id']
         channel_history = self.slack_api_http(api_endpoint=api_endpoint,
@@ -165,7 +185,7 @@ This script was run from this repo: https://github.com/Symantec/slack-autoarchiv
         # self.settings.get('skip_channel_str')
         # if the channel purpose contains the string self.settings.get('skip_channel_str'), we'll skip it.
         info_payload = {'channel': channel['id']}
-        channel_info = self.slack_api_http(api_endpoint='channels.info',
+        channel_info = self.slack_api_http(api_endpoint='conversations.info',
                                            payload=info_payload,
                                            method='GET')
         channel_purpose = channel_info['channel']['purpose']['value']
@@ -197,7 +217,7 @@ This script was run from this repo: https://github.com/Symantec/slack-autoarchiv
 
     def archive_channel(self, channel, alert):
         """ Archive a channel, and send alert to slack admins. """
-        api_endpoint = 'channels.archive'
+        api_endpoint = 'conversations.archive'
         stdout_message = 'Archiving channel... %s' % channel['name']
         self.logger.info(stdout_message)
 
@@ -205,7 +225,7 @@ This script was run from this repo: https://github.com/Symantec/slack-autoarchiv
             channel_message = alert.format(self.settings.get('days_inactive'))
             self.send_channel_message(channel['id'], channel_message)
             payload = {'channel': channel['id']}
-            self.slack_api_http(api_endpoint=api_endpoint, payload=payload)
+            self.slack_api_http(api_endpoint=api_endpoint, payload=payload, method='POST')
             self.logger.info(stdout_message)
 
     def send_admin_report(self, channels):


### PR DESCRIPTION
- Slack channels endpoints deprecated in Feb, 2021; repalced by conversations endpoints (taken from https://github.com/Symantec/slack-autoarchive/pull/51)
- Handled large list of channels by adding pagination capabilities using cursor
- Update Slack APIs usage as the specs changed. Also add the feature to forcefully archive channel from a blacklist
